### PR TITLE
[전체 QA] 설정페이지 고객명 뒤 "님" 누락 현상

### DIFF
--- a/src/pages/service/setting/setting.html
+++ b/src/pages/service/setting/setting.html
@@ -63,7 +63,7 @@
                             </header>
                             <div class="card-box">
                                 <header>
-                                    <h2 class="username"><span id="profile-username"></span> 환영합니다.</h2>
+                                    <h2 class="username"><span id="profile-username"></span>님 환영합니다.</h2>
                                 </header>
                                 <div class="binance-link-status">
                                     <div class="state-box">


### PR DESCRIPTION
고객명 뒤에 “님”이 붙어있지 않음 -> 기획서와 동일하게 고객명 뒤에 “님”이 붙어있어야 함